### PR TITLE
use notebook classic

### DIFF
--- a/.nbhosting/Dockerfile
+++ b/.nbhosting/Dockerfile
@@ -1,7 +1,7 @@
 # --------
 # using scipy, it's kinda big but that should not be a problem
 # base-notebook lacks at least numpy, widgets, so...
-FROM nbhosting/scipy-notebook
+FROM nbhosting/scipy-notebook:nb6
 
 RUN true \
     # latest release of nbautoeval \


### PR DESCRIPTION
I am the maintainer of nbhosting.inria.fr where this repo is hosted

with notebook 7 being out, I advise that you merge this change
so as to pin your base image to one that has nbclassic (aka nb6)

I took this opportunity to also use new name .nbhosting for the config folder

